### PR TITLE
Adding a Default activity for post-login - whenever Flex loads, and a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This plugin addresses a few common needs in many contact centers:
 
 * Changing the worker's activity when they're handling tasks and when their tasks are in wrapup.
   * This makes it easier to monitor what workers are doing in realtime, and improves workforce management visibility in Flex Insights for historical reporting
+* Changing the worker's activity to a default activity upon login
+  * Again, helps with real-time workforce management visibility and allows for more accurate reporting on post-login/pre-Available duration
 * Ability to define activities that should not be manually selected, such as the activities used to indicate the worker is handling tasks or in wrapup
 * Preventing the worker from changing their activity while they're on a task, delaying that activity change until after they've completed their tasks
   * Changing to another activity like "Break" while the agent is actively handling tasks can result in inaccurate activity based reporting. Preventing that change until they're actually complete with their tasks aids in reporting and monitoring accuracy.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "plugin-activity-handler",
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
@@ -1820,7 +1821,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -4669,7 +4669,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -6912,8 +6911,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -7679,7 +7677,6 @@
         "flex-plugins-utils-logger": "^0.18.0",
         "flex-plugins-utils-spawn": "^0.18.2",
         "globby": "^11.0.1",
-        "keytar": "^7.2.0",
         "lodash": "^4.17.20",
         "marked": "^1.2.2",
         "marked-terminal": "^4.1.0",
@@ -8874,7 +8871,6 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -10972,7 +10968,6 @@
         "@jest/types": "^24.9.0",
         "anymatch": "^2.0.0",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^1.2.7",
         "graceful-fs": "^4.1.15",
         "invariant": "^2.2.4",
         "jest-serializer": "^24.9.0",
@@ -11417,7 +11412,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -19779,10 +19773,8 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dependencies": {
-        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.1"
+        "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -19872,7 +19864,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -20289,7 +20280,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "postinstall": "flex-plugin pre-script-check"
+    "postinstall": "flex-plugin pre-script-check",
+    "lazy-deploy": "twilio flex:plugins:deploy --major --changelog 'Lazy change description' --description 'Lazy plugin description'"
   },
   "dependencies": {
     "flex-plugin-scripts": "^4.3.18-beta.0",

--- a/src/enums/index.js
+++ b/src/enums/index.js
@@ -10,6 +10,7 @@ export const ReservationEvents = {
 
 export const Activity = {
   available: 'Available',
+  defaultLoggedIn: 'Unavailable Default',
   onATask: 'On a Task',
   onATaskNoAcd: 'On a Task, No ACD',
   wrapup: 'Wrap Up',

--- a/src/listeners/index.js
+++ b/src/listeners/index.js
@@ -12,6 +12,11 @@ const manager = Manager.getInstance();
 const reservationListeners = new Map();
 
 const availableActivity = FlexState.getActivityByName(Activity.available);
+
+// Update 'Activity.defaultLoggedIn' value to match the activity name you're
+// using to indicate an agent has logged into Flex, but not selected an
+// activity
+const defaultLoggedInActivity = FlexState.getActivityByName(Activity.defaultLoggedIn);
 // Update 'Activity.onATask' value to match the activity name you're
 // using to indicate an agent has an active task
 const onTaskActivity = FlexState.getActivityByName(Activity.onATask);
@@ -30,6 +35,7 @@ const wrapupNoAcdActivity = FlexState.getActivityByName(Activity.wrapupNoAcd);
 // The activities in this array can only be set programmatically and will
 // not be stored as pending activities to switch the user back to
 const systemActivities = [
+  Activity.defaultLoggedIn,
   Activity.onATask,
 	Activity.onATaskNoAcd,
   Activity.wrapup,
@@ -146,7 +152,9 @@ const validateAndSetWorkerActivity = () => {
 		setWorkerActivity(targetActivity?.sid, pendingActivity ? true : false);
 	}
 	else if (workerActivitySid === FlexState.offlineActivitySid && !FlexState.hasWrappingTask) {
-		FlexState.clearPendingActivityChange();
+		// Assume fresh login with no ongoing tasks. Move to Default activity and clear pending
+		// activities if any
+		setWorkerActivity(defaultLoggedInActivity?.sid, true);
 	}
 }
 //#endregion Supporting functions


### PR DESCRIPTION
Customer wanted to have an equivalent to the traditional Default Aux state (i.e. post-login initial unavailable state). This is another state that should not be manually selectable. Piggybacked on existing logic that engages when agent is in Offline activity upon Flex initialization, and has no tasks.

I wanted to also make Offline a non-selectable activity, but that would remove the natural ability to queue up a pending Offline activity change while handling tasks - so opted against that idea.